### PR TITLE
Bug fix: Log file naming.

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -101,12 +101,18 @@ impl Logger {
         }
 
         self.file = None;
-        self.current_index = 0;
         self.used_length = 0;
 
         self.setting = setting;
 
         self.init = true;
+
+        self.current_file_prefix =  format!(
+            "{}",
+            chrono::Utc::now()
+                .with_timezone(&FixedOffset::east_opt(self.setting.time_zone * 3600).unwrap())
+                .format("%Y-%m-%d")
+        );
         self.current_index = self.get_index(&self.current_file_prefix).await;
     }
 
@@ -114,6 +120,12 @@ impl Logger {
     pub(crate) async fn set(&mut self, setting: Setting) {
         self.init = true;
         self.setting = setting;
+        self.current_file_prefix = format!(
+            "{}",
+            chrono::Utc::now()
+                .with_timezone(&FixedOffset::east_opt(self.setting.time_zone * 3600).unwrap())
+                .format("%Y-%m-%d")
+        );
         self.current_index = self.get_index(&self.current_file_prefix).await;
         self.file = Some(self.get_file().await);
     }
@@ -267,12 +279,18 @@ impl Logger {
         }
 
         self.file = None;
-        self.current_index = 0;
         self.used_length = 0;
 
         self.setting = setting;
 
         self.init = true;
+
+        self.current_file_prefix = format!(
+            "{}",
+            chrono::Utc::now()
+                .with_timezone(&FixedOffset::east_opt(self.setting.time_zone * 3600).unwrap())
+                .format("%Y-%m-%d")
+        );
         self.current_index = self.get_index(&self.current_file_prefix);
     }
 
@@ -280,6 +298,12 @@ impl Logger {
     pub(crate) fn set(&mut self, setting: Setting) {
         self.init = true;
         self.setting = setting;
+        self.current_file_prefix = format!(
+            "{}",
+            chrono::Utc::now()
+                .with_timezone(&FixedOffset::east_opt(self.setting.time_zone * 3600).unwrap())
+                .format("%Y-%m-%d")
+        );
         self.current_index = self.get_index(&self.current_file_prefix);
         self.file = Some(self.get_file());
     }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -165,7 +165,7 @@ impl Logger {
             );
             if self.current_file_prefix != time_prefix {
                 self.current_file_prefix = time_prefix;
-                self.current_index = 0;
+                self.current_index = self.get_index(&self.current_file_prefix).await;
                 self.used_length = 0;
                 self.file = Some(self.get_file().await);
             };
@@ -344,7 +344,7 @@ impl Logger {
             );
             if self.current_file_prefix != time_prefix {
                 self.current_file_prefix = time_prefix;
-                self.current_index = 0;
+                self.current_index = self.get_index(&self.current_file_prefix);
                 self.used_length = 0;
                 self.file = Some(self.get_file());
             };


### PR DESCRIPTION
**Addressing** Issue #8 .

Update the `current_file_prefix` attribute of the _Logger_ when a _Setting_ is applied.

Use `get_index(...)` to get a new `current_index` attribute when the date had changed instead of setting it to _0_ .